### PR TITLE
[scripts/make_stubs.py] copy non-HTML keep-files in --mirror-canonical mode

### DIFF
--- a/scripts/make_stubs.py
+++ b/scripts/make_stubs.py
@@ -34,6 +34,7 @@ Usage:
 
 import argparse
 import os
+import shutil
 import sys
 import urllib.parse
 from pathlib import Path
@@ -86,6 +87,12 @@ def iter_alias_html(alias: Path):
     # symlinked subtrees inside alias are skipped instead of accidentally
     # rewriting files outside the alias.
     for root, _, files in os.walk(alias):
+        for name in files:
+            yield Path(root) / name, name
+
+
+def iter_canonical_files(canonical: Path):
+    for root, _, files in os.walk(canonical):
         for name in files:
             yield Path(root) / name, name
 
@@ -157,12 +164,26 @@ def main() -> int:
     bytes_after = 0
 
     if args.mirror_canonical:
-        for canonical_path, name in iter_canonical_html(canonical):
-            if name in keep:
-                skipped_keep += 1
-                continue
+        for canonical_path, name in iter_canonical_files(canonical):
             rel = canonical_path.relative_to(canonical)
             alias_path = alias / rel
+            if name in keep:
+                # Keep-files are byte-copied so external fetchers (intersphinx
+                # objects.inv, full-text searchindex.js, .buildinfo) can still
+                # resolve under the alias URL.
+                old_size = alias_path.stat().st_size if alias_path.is_file() else 0
+                new_size = canonical_path.stat().st_size
+                bytes_before += old_size
+                bytes_after += new_size
+                skipped_keep += 1
+                if not args.dry_run:
+                    alias_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(canonical_path, alias_path)
+                if not args.quiet:
+                    print(f"  copy: {rel}  ({new_size} bytes, kept)")
+                continue
+            if canonical_path.suffix.lower() != ".html":
+                continue
             stub = make_stub(alias_path, canonical_path, rel, args.url_prefix)
             new_size = len(stub.encode("utf-8"))
             old_size = alias_path.stat().st_size if alias_path.is_file() else 0


### PR DESCRIPTION
## Summary

Follow-up to #84.

`make_stubs.py` already has

```python
DEFAULT_KEEP = {"searchindex.js", "objects.inv", ".buildinfo"}
```

with intent to preserve those files as real bytes under each alias, and the default `walk-alias` mode honors it correctly. The bug: `--mirror-canonical` mode iterates `iter_canonical_html()` (filtered to `.html`), so keep-listed files are never copied. Net effect after #84: every alias directory (`stable/`, `master/`, `1.7.0/`, `1.9.0/`) is missing `objects.inv`, `searchindex.js`, and `.buildinfo`.

`https://pytorch.org/docs/stable/objects.inv` returning 404 breaks intersphinx for every downstream Sphinx/mkdocstrings project that cross-references PyTorch. Three projects shipped pin-to-version workarounds within the first 12 hours after #84 merged (vllm-project/vllm#41353, isaac-sim/IsaacLab#5452, newton-physics/newton#2660). Several more (Lightning, pytorch/{vision,audio,text}, skorch) intersphinx `/docs/stable/` and will go red on their next docs rebuild. Tracking issue at pytorch/pytorch#&lt;to-be-filed&gt;.

## Fix

Make `--mirror-canonical` walk the full canonical (not just `.html`), byte-copy keep-listed files, and stub the HTML as before. Default `walk-alias` mode is unchanged. ~30-line diff.

## Cost

Adds back ~13 MB across the four aliases #84 stubbed:

| alias  | objects.inv | searchindex.js | total kept |
|--------|------------:|---------------:|-----------:|
| stable | 0.18 MB     | 3.07 MB        | ~3.3 MB    |
| master | similar     | similar        | ~3.3 MB    |
| 1.7.0  | smaller     | smaller        | ~3 MB      |
| 1.9.0  | smaller     | smaller        | ~3 MB      |

Pre-#84 artifact was ~3.4 GB of dereferenced HTML duplication; #84 took it to ~5 MB; this PR takes it to ~17 MB. Still 99.5% of #84's savings, far under the 10 GB Pages cap.

## Verification

Local repro on a synthetic canonical (`canonical/{index,torch,sub/nested}.html` plus `canonical/{objects.inv,searchindex.js,.buildinfo}`):

Before:
```
$ python3 scripts/make_stubs.py --alias alias_unpatched --canonical canonical --mirror-canonical
stubbed:      3 files
kept:         0 files (matched --keep)
$ ls alias_unpatched
index.html  sub/  torch.html
```

After:
```
$ python3 scripts/make_stubs.py --alias alias_patched --canonical canonical --mirror-canonical
  stub: index.html  (646 bytes)
  stub: torch.html  (646 bytes)
  copy: searchindex.js  (24 bytes, kept)
  copy: .buildinfo  (10 bytes, kept)
  copy: objects.inv  (18 bytes, kept)
  stub: sub/nested.html  (686 bytes)
stubbed:      3 files
kept:         3 files (matched --keep)
$ ls alias_patched
.buildinfo  index.html  objects.inv  searchindex.js  sub/  torch.html
$ cmp canonical/objects.inv alias_patched/objects.inv && echo OK
OK
```

Default `walk-alias` mode unchanged: same synthetic input, keep-files left untouched, HTML rewritten to stubs.

## Test plan

- [x] Local: bug reproduced on the unpatched script; fix produces byte-identical keep-files plus HTML stubs; default walk-alias mode unchanged.
- [ ] On merge: confirm `pytorch.org/docs/stable/objects.inv` returns 200 with the same bytes as `pytorch.org/docs/2.11/objects.inv`.